### PR TITLE
Add CC BY SA to license options for site content

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,6 +1,9 @@
 Unless otherwise specified, the code in the repository is available under
 the MIT license.
 
+Unless otherwise specified, the non-code content, such as documentation, in
+the repository is available under the CC BY SA 4.0 Unported license.
+
 ---
 
 The MIT License (MIT)
@@ -24,3 +27,21 @@ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
+
+---
+
+This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 Unported License.
+
+http://creativecommons.org/licenses/by-sa/3.0/
+
+You are free to:
+
+Share — copy and redistribute the material in any medium or format
+Adapt — remix, transform, and build upon the material for any purpose, even commercially.
+
+The licensor cannot revoke these freedoms as long as you follow the license terms.
+Under the following terms:
+
+Attribution — You must give appropriate credit, provide a link to the license, and indicate if changes were made. You may do so in any reasonable manner, but not in any way that suggests the licensor endorses you or your use.
+ShareAlike — If you remix, transform, or build upon the material, you must distribute your contributions under the same license as the original.
+No additional restrictions — You may not apply legal terms or technological measures that legally restrict others from doing anything the license permits.


### PR DESCRIPTION
The MIT license is not a content and documentation license, per-se. It is true that the license /can/ cover documentation, but it is not an optimum choice. With the more widely accepted and used free culture Creative Commons licenses, the project signals that it is interesting in going away from being a content island and instead joining the mainland of content.

For example, putting this license forward AND posting it in the footer of the website (a future pull request) will signal to people that they are free to use/reuse/ modify blog content as they are with code.

However, I'll admit to not being sure the 4.0 Interrnational version of this license is the right choice. In fact, the Wikemedia Foundation legal team does not think the 4.0 is backwards compatible to the 3.0:

https://en.wikipedia.org/wiki/Wikipedia:FAQ/Copyright#Can_I_add_something_to_Wikipedia_that_I_got_from_somewhere_else.3F

As there is a large body of 3.0 content out there, I'm suggesting that one for now.

I think the BY SA options are philosophically aligned with the MIT, but am not a lawyer to say anything more.
